### PR TITLE
Fix project namespaces and broken email template references.

### DIFF
--- a/Controllers/EmailController.cs
+++ b/Controllers/EmailController.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
-using YourApp.Models;
-using YourApp.Services;
+using AutoEmail.Models;
+using AutoEmail.Services;
 
-namespace YourApp.Controllers;
+namespace AutoEmail.Controllers;
 
 public class EmailController : Controller
 {
@@ -25,7 +25,7 @@ public class EmailController : Controller
         if (!ModelState.IsValid) return View(req);
 
         // 用 Razor 模板產出 HTML 內容
-        var html = await _renderer.RenderViewToStringAsync("/Views/Email/Templates/Welcome.cshtml", new {
+        var html = await _renderer.RenderViewToStringAsync("/Views/Email/Templates/Content.cshtml", new {
             UserName = string.IsNullOrWhiteSpace(req.UserName) ? "朋友" : req.UserName,
             Message = req.Message
         });

--- a/Models/EmailRequest.cs
+++ b/Models/EmailRequest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace YourApp.Models;
+namespace AutoEmail.Models;
 
 public class EmailRequest
 {

--- a/Models/EmailSettings.cs
+++ b/Models/EmailSettings.cs
@@ -1,4 +1,4 @@
-namespace YourApp.Models;
+namespace AutoEmail.Models;
 
 public class EmailSettings
 {

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,5 @@
-using YourApp.Models;
-using YourApp.Services;
+using AutoEmail.Models;
+using AutoEmail.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Services/IEmailSender.cs
+++ b/Services/IEmailSender.cs
@@ -1,4 +1,4 @@
-namespace YourApp.Services;
+namespace AutoEmail.Services;
 
 public interface IEmailSender
 {

--- a/Services/IRazorViewRenderer.cs
+++ b/Services/IRazorViewRenderer.cs
@@ -1,4 +1,4 @@
-namespace YourApp.Services;
+namespace AutoEmail.Services;
 
 public interface IRazorViewRenderer
 {

--- a/Services/RazorViewRenderer.cs
+++ b/Services/RazorViewRenderer.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-namespace YourApp.Services;
+namespace AutoEmail.Services;
 
 public class RazorViewRenderer : IRazorViewRenderer
 {

--- a/Services/ScheduledEmailService.cs
+++ b/Services/ScheduledEmailService.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
-using YourApp.Models;
+using AutoEmail.Models;
 
-namespace YourApp.Services;
+namespace AutoEmail.Services;
 
 public class ScheduledEmailOptions
 {
@@ -10,7 +10,7 @@ public class ScheduledEmailOptions
     public int DailyMinute { get; set; } = 0;
     public string To { get; set; } = "";
     public string Subject { get; set; } = "每日通知";
-    public string Template { get; set; } = "Welcome";
+    public string Template { get; set; } = "Content";
     public Dictionary<string, string> TemplateModel { get; set; } = new();
 }
 

--- a/Services/SmtpEmailSender.cs
+++ b/Services/SmtpEmailSender.cs
@@ -2,9 +2,9 @@ using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
 using Microsoft.Extensions.Options;
-using YourApp.Models;
+using AutoEmail.Models;
 
-namespace YourApp.Services;
+namespace AutoEmail.Services;
 
 public class SmtpEmailSender : IEmailSender
 {

--- a/Views/Email/Send.cshtml
+++ b/Views/Email/Send.cshtml
@@ -1,4 +1,4 @@
-@model YourApp.Models.EmailRequest
+@model AutoEmail.Models.EmailRequest
 @{
     ViewData["Title"] = "寄信範例";
 }


### PR DESCRIPTION
The project was using a generic 'YourApp' namespace. This has been updated to 'AutoEmail' to match the project's purpose.

A runtime bug was fixed where the code referenced a non-existent email template 'Welcome.cshtml'. The references have been updated to point to the correct 'Content.cshtml' template.